### PR TITLE
fix: swap Volumes for HostConfig.Binds

### DIFF
--- a/src/controllers/ContainerController.ts
+++ b/src/controllers/ContainerController.ts
@@ -72,8 +72,10 @@ export class ContainerController {
         Env: options.environment,
         Labels: options.labels,
         ExposedPorts: ports.ExposedPorts,
-        Volumes: options.volumes,
-        Cmd: options.command
+        HostConfig: {
+          Binds: options.volumes ?? [],
+        },
+        Cmd: options.command,
       });
 
       if (options.start) {

--- a/src/validators/Containers.ts
+++ b/src/validators/Containers.ts
@@ -17,7 +17,7 @@ export const createContainerSchema = z.object({
   workingdir: z.string().optional(),
   start: z.boolean().optional(),
   labels: z.record(z.string()).optional(),
-  volumes: z.record(z.object({})).optional(),
+  volumes: z.array(z.string()).optional(),
 });
 
 // Labels?: { [label: string]: string } | undefined;


### PR DESCRIPTION
fix:

- Uses HostConfig.Binds instead of Volumes when creating a new container