### PR TITLE
fix: patch networks to default to tugboat

### DIFF
--- a/src/controllers/ContainerController.ts
+++ b/src/controllers/ContainerController.ts
@@ -75,12 +75,12 @@ export class ContainerController {
         HostConfig: {
           Binds: options.volumes ?? [],
           PortBindings: ports.PortBindings,
-          NetworkMode: options.networks?.[0] || "bridge",
+          NetworkMode: options.networks?.[0] || "tugboat",
         },
         Cmd: options.command,
         NetworkingConfig: {
           EndpointsConfig: {
-            [options.networks?.[0] || "bridge"]: {
+            [options.networks[0] || "tugboat"]: {
               Aliases: [options.name],
             },
           },


### PR DESCRIPTION
Fix:

Default to "tugboat" network if no networks are provided during Container creation because Docker doesn't allow network-scoped aliases on the default bridge network.