### PR TITLE
feat: move to events-based monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .vscode 
 .env
+.env.local
+
 node_modules
 dist
-.env.linux
 repos
+tugboat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,15 @@ services:
     container_name: tugboat
     image: tugboat:latest
     env_file:
-      - .env.linux
+      - .env.local
     ports:
       - "7567:7567"
     volumes:
-       - /var/run/docker.sock:/var/run/docker.sock
-       - ~/tugboat:/tugboat
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/tugboat:/tugboat
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
-volumes:
-  tugboat:
-    driver: shared
+networks:
+  default:
+    driver: bridge

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "tugboat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tugboat",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@hono/zod-validator": "^0.4.3",
         "axios": "^1.8.3",
+        "chalk": "^5.6.2",
         "dockerode": "^4.0.4",
         "dotenv": "^16.4.7",
         "hono": "^4.7.4",
@@ -502,6 +503,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "tugboat",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A node.js agent for managing remote Docker containers.",
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --exec ts-node src/app.ts",
     "build": "tsc",
     "start": "node dist/app.js",
-    "docker:build": "docker build -t tugboat .",
-    "docker:run": "docker stop tugboat && docker rm tugboat && docker run --name tugboat --env-file ./tugboat/.env -p 7567:7567 -v /var/run/docker.sock:/var/run/docker.sock -v //./pipe/docker_engine://./pipe/docker_engine -v \"/tugboat:/tugboat\" tugboat:latest"
+    "docker:build": "docker build -t tugboat ."
   },
   "keywords": [],
   "author": "",
@@ -17,6 +16,7 @@
     "@hono/node-server": "^1.13.8",
     "@hono/zod-validator": "^0.4.3",
     "axios": "^1.8.3",
+    "chalk": "^5.6.2",
     "dockerode": "^4.0.4",
     "dotenv": "^16.4.7",
     "hono": "^4.7.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import { DockerService } from "./services/Docker";
 import { ensureSecretKey } from "./utils/auth";
 import { checkEnv } from "./utils/env";
 import { NetworkController } from "./controllers/NetworkController";
+import { WatcherService } from "./services/Watcher";
 
 dotenv.config();
 
@@ -22,17 +23,16 @@ checkEnv();
 ensureSecretKey();
 
 const dockerService = new DockerService();
+const watcherService = new WatcherService();
 const heartbeat = new HeartbeatService(dockerService);
 
-// Start phone home interval
-if (process.env.TUGBOAT_PHONE_HOME_INTERVAL !== null && process.env.TUGBOAT_PHONE_HOME_URL !== null) {
-  heartbeat.start();
-}
+watcherService.start();
+heartbeat.start();
 
 const containerController = new ContainerController(dockerService);
+const networkController = new NetworkController(dockerService);
 const imageController = new ImageController(dockerService);
 const githubController = new GithubController();
-const networkController = new NetworkController(dockerService);
 
 const application = new Application(containerController, imageController, githubController, networkController);
 

--- a/src/controllers/ContainerController.ts
+++ b/src/controllers/ContainerController.ts
@@ -5,7 +5,7 @@ import { DockerService } from "../services/Docker";
 import { demultiplexDockerStream, stripAnsiCodes } from "../utils/transformers";
 import { PassThrough } from "stream";
 import { parsePortString } from "../utils/ports";
-import { httpService } from "../services/HttpService";
+import { httpService } from "../services/Http";
 
 export class ContainerController {
   private docker: DockerService;

--- a/src/controllers/ImageController.ts
+++ b/src/controllers/ImageController.ts
@@ -1,6 +1,6 @@
 import { Context } from "hono";
 import { DockerService } from "../services/Docker";
-import { httpService } from "../services/HttpService";
+import { httpService } from "../services/Http";
 
 import path from "path";
 import os from "os";

--- a/src/services/Http.ts
+++ b/src/services/Http.ts
@@ -1,11 +1,12 @@
 import axios, { AxiosInstance } from "axios";
 import { config } from "dotenv";
+import { warn } from "../utils/console";
 
 config(); // Load environment variables from .env file
 
 class HttpService {
-  private client: AxiosInstance | null = null; // Axios instance for HTTP requests
-  private readonly endpoint = "/"; // Hardcoded endpoint
+  private client: AxiosInstance | null = null;
+  private readonly endpoint = "/events";
 
   constructor() {
     if (!process.env.TUGBOAT_PHONE_HOME_URL) {
@@ -13,14 +14,14 @@ class HttpService {
     }
 
     this.client = axios.create({
-      baseURL: process.env.TUGBOAT_PHONE_HOME_URL, // Set the base URL
-      timeout: 5000, // Set a default timeout
+      baseURL: process.env.TUGBOAT_PHONE_HOME_URL,
+      timeout: 5000,
     });
   }
 
   async post(data: any) {
     if (!this.client) {
-      console.warn("HTTP client is not initialized. Skipping POST request.");
+      warn("Http", "HTTP client is not initialized. Skipping POST request.");
       return;
     }
 

--- a/src/services/Server.ts
+++ b/src/services/Server.ts
@@ -10,6 +10,7 @@ import { createImageSchema, pullImageSchema } from "../validators/Images";
 import { GithubController } from "../controllers/GithubController";
 import { NetworkController } from "../controllers/NetworkController";
 import { createNetworkSchema } from "../validators/Networks";
+import { info } from "../utils/console";
 
 export class Application {
   private app: Hono;
@@ -76,8 +77,8 @@ export class Application {
         port: process.env.TUGBOAT_PORT ? parseInt(process.env.TUGBOAT_PORT) : 3000,
         fetch: this.app.fetch.bind(this.app),
       },
-      info => {
-        console.log(`Server listening on http://localhost:${info.port}`);
+      data => {
+        info("Hono", `Server started on port ${data.port}`);
       }
     );
   }

--- a/src/services/Watcher.ts
+++ b/src/services/Watcher.ts
@@ -1,0 +1,120 @@
+import { ChildProcessByStdio, spawn } from "child_process";
+import { error, info } from "../utils/console";
+import { httpService } from "./Http";
+import { Readable } from "stream";
+
+export class WatcherService {
+private spawnedProcess: ChildProcessByStdio<null, Readable, Readable> | null = null;
+  private buffer = "";
+  private retryDelay = 5000;
+
+  // Start watching the Docker events
+  start() {
+    if (this.spawnedProcess) {
+      info("Watcher", "Docker event watcher already running");
+      return;
+    }
+
+    info("Watcher", "Starting Docker event watcher...");
+
+    this.spawnedProcess = spawn("docker", ["events", "--format", "{{json .}}"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    this.spawnedProcess.stdout.on("data", chunk => this.handleChunk(chunk));
+    this.spawnedProcess.stderr.on("data", data => {
+      error("Watcher", `Docker events stderr: ${data.toString().trim()}`);
+    });
+
+    this.spawnedProcess.on("error", err => {
+      error("Watcher", `Failed to spawn docker events: ${err.message}`);
+    });
+
+    this.spawnedProcess.on("exit", code => {
+      error("Watcher", `Docker events process exited with code ${code}`);
+      this.spawnedProcess = null;
+
+      // auto-restart after backoff
+      setTimeout(() => this.start(), this.retryDelay);
+    });
+  }
+
+  // Stop watching the Docker events
+  stop() {
+    if (!this.spawnedProcess) return;
+
+    info("Watcher", "Stopping Docker event watcher...");
+    this.spawnedProcess.kill();
+    this.spawnedProcess = null;
+  }
+
+  // Restart the watcher
+  restart() {
+    info("Watcher", "Restarting Docker event watcher...");
+    this.stop();
+    this.start();
+  }
+
+  // Cleanup on shutdown
+  shutdown() {
+    info("Watcher", "Shutting down Docker event watcher...");
+    this.stop();
+  }
+
+  // Handle raw stdout chunks (buffer + parse by line)
+  private handleChunk(chunk: Buffer) {
+    this.buffer += chunk.toString();
+    let index;
+    while ((index = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, index).trim();
+      this.buffer = this.buffer.slice(index + 1);
+      if (!line) continue;
+
+      try {
+        const event = JSON.parse(line) as DockerEvent;
+        this.handleEvent(event);
+      } catch (err) {
+        error("Watcher", `Failed to parse Docker event: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  // Handle parsed Docker event
+  private async handleEvent(event: DockerEvent) {
+    if (!this.shouldForward(event)) return;
+
+    try {
+      await httpService.post({
+        type: "docker_event",
+        payload: {
+          event: event.Action,
+          type: event.Type,
+          id: event.Actor.ID,
+          attributes: event.Actor.Attributes,
+        },
+      });
+    } catch (err) {
+      error("Watcher", `Failed to forward event: ${(err as Error).message}`);
+    }
+  }
+
+  // Filter logic (customizable later)
+  private shouldForward(event: DockerEvent): boolean {
+    if (event.Type !== "container") return false;
+    if (event.Action === "stop" || event.Action === "kill") return false;
+    return true;
+  }
+}
+
+interface DockerEvent {
+  Type: "container" | "image" | "volume" | "network" | "plugin" | string;
+  Action: string;
+  Actor: {
+    ID: string;
+    Attributes: Record<string, string>;
+  };
+  time: number;
+  timeNano: number;
+  scope?: "local" | "swarm";
+  status?: string;
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,8 @@
 import crypto from "crypto";
 import fs from "fs";
 
-import { httpService } from "../services/HttpService";
+import { httpService } from "../services/Http";
+import { info, error } from "./console";
 
 /**
  * Ensures that TUGBOAT_SECRET_KEY is set. If not, generates a new key,
@@ -17,12 +18,12 @@ export function ensureSecretKey() {
       const match = envContent.match(/^TUGBOAT_SECRET_KEY=(.+)$/m);
       if (match) {
         process.env.TUGBOAT_SECRET_KEY = match[1];
-        console.log("TUGBOAT_SECRET_KEY loaded from .env file.");
+        info("Env", "TUGBOAT_SECRET_KEY loaded from .env file.");
         return;
       }
     }
-  } catch (error: any) {
-    console.error("Failed to read .env file:", error.message);
+  } catch (e: any) {
+    error("Env", `Failed to read .env file: ${e.message}`);
   }
 
   // Generate a new key if not found
@@ -32,9 +33,9 @@ export function ensureSecretKey() {
   // Append the key to the .env file
   try {
     fs.appendFileSync(envPath, `TUGBOAT_SECRET_KEY=${newKey}\n`);
-    console.log("TUGBOAT_SECRET_KEY saved to .env file.");
-  } catch (error: any) {
-    console.error("Failed to save TUGBOAT_SECRET_KEY to .env file:", error.message);
+    info("Env", "TUGBOAT_SECRET_KEY saved to .env file.");
+  } catch (e: any) {
+    error("Env", `Failed to save TUGBOAT_SECRET_KEY to .env file: ${e.message}`);
   }
 
   // Send the key to PHONE_HOME_URL if defined
@@ -44,9 +45,9 @@ export function ensureSecretKey() {
       secretKey: newKey,
     })
     .then(() => {
-      console.log("New secret key sent to PHONE_HOME_URL.");
+      info("Env", "TUGBOAT_SECRET_KEY sent to PHONE_HOME_URL.");
     })
-    .catch(error => {
-      console.error("Failed to send secret key to PHONE_HOME_URL:", error.message);
+    .catch(e => {
+      error("Env", `Failed to send TUGBOAT_SECRET_KEY to PHONE_HOME_URL: ${e.message}`);
     });
 }

--- a/src/utils/console.ts
+++ b/src/utils/console.ts
@@ -1,0 +1,17 @@
+import chalk from "chalk";
+
+export function info(prefix: string, message: string) {
+  console.log(chalk.blueBright(`[ ${prefix} ]`), message);
+}
+
+export function warn(prefix: string, message: string) {
+  console.warn(chalk.yellow(`[ ${prefix} ]`), message);
+}
+
+export function error(prefix: string, message: string) {
+  console.error(chalk.red(`[ ${prefix} ]`), message);
+}
+
+export function success(prefix: string, message: string) {
+  console.log(chalk.green(`[ ${prefix} ]`), message);
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,8 +1,10 @@
 // Checks all environment variables are set
 
+import { info } from "./console";
+
 export function checkEnv() {
-  let requiredEnv = ["TUGBOAT_PORT"];
-  let optionalEnv = ["TUGBOAT_PHONE_HOME_INTERVAL", "TUGBOAT_PHONE_HOME_URL"];
+  const requiredEnv = ["TUGBOAT_PORT"];
+  const optionalEnv = ["TUGBOAT_PHONE_HOME_URL"];
 
   for (const env of requiredEnv) {
     if (!process.env[env]) {
@@ -12,7 +14,7 @@ export function checkEnv() {
 
   for (const env of optionalEnv) {
     if (!process.env[env]) {
-      console.log(`${env} environment variable is not set. This instance will not phone home.`);
+      info("Env", `${env} environment variable is not set, skipping`);
     }
   }
 }


### PR DESCRIPTION
This PR changes how Tugboat monitors Docker, System Usage and Heartbeats.

- Moves container and usage heartbeats to their own interval every 5 minutes
- Reduces the minute heartbeat to a simple "alive" payload.
- Tracks more system metrics; disk space, network usage over interval

Additionally, instead of sending containers every minute, Tugboat now listens to `docker events` instead and triggers a http request to PHONE_HOME_URL when Container events happen. (added in new Watcher.ts file)